### PR TITLE
Create .gitattributes for line endings and binaries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,29 @@
+
+* text=auto
+
+*.cs text eol=lf
+
+*.csproj text eol=lf
+*.sln text eol=crlf
+*.props text eol=lf
+*.targets text eol=lf
+
+*.json text eol=lf
+*.xml text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.config text eol=lf
+*.md text eol=lf
+
+*.sh text eol=lf
+*.bash text eol=lf
+*.ps1 text eol=crlf
+
+*.dll binary
+*.exe binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary


### PR DESCRIPTION
Add .gitattributes file to manage line endings and binary files.